### PR TITLE
[fix]: fix config task when BUILD_DIR not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "gulp-rename": "^1.2.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.16.4",
-    "mkdirp": "^0.5.1",
     "pro-gulp": "^0.3.0",
     "webpack": "^1.13.2",
     "yargs": "^6.3.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "browser-sync": "^2.17.5",
     "connect-history-api-fallback": "^1.3.0",
     "dotenv": "^2.0.0",
+    "fs-extra": "^2.1.2",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
     "gulp-cssnano": "^2.1.2",

--- a/src/tasks/build.js
+++ b/src/tasks/build.js
@@ -3,7 +3,6 @@ const {execSync} = require("child_process");
 const fs = require("fs-extra");
 const gulp = require("gulp");
 const gulpLoadPlugins = require("gulp-load-plugins");
-const mkdirp = require("mkdirp");
 const proGulp = require("pro-gulp");
 const webpack = require("webpack");
 
@@ -58,7 +57,7 @@ proGulp.task("buildAllScripts", (() => {
             compiler = null;
         }
         const deps = JSON.parse(fs.readFileSync(DEPS_PATH));
-        mkdirp.sync(`${BUILD_DIR}/_assets/js`);
+        fs.mkdirpSync(`${BUILD_DIR}/_assets/js`);
         compiler = compiler || webpack({
             entry: {
                 app: `${APP_DIR}/main.jsx`,

--- a/src/tasks/build.js
+++ b/src/tasks/build.js
@@ -1,6 +1,6 @@
 const {promisify} = require("bluebird");
 const {execSync} = require("child_process");
-const fs = require("fs");
+const fs = require("fs-extra");
 const gulp = require("gulp");
 const gulpLoadPlugins = require("gulp-load-plugins");
 const mkdirp = require("mkdirp");

--- a/src/tasks/config.js
+++ b/src/tasks/config.js
@@ -1,5 +1,5 @@
 const dotenv = require("dotenv");
-const fs = require("fs");
+const fs = require("fs-extra");
 const _ = require("lodash");
 const proGulp = require("pro-gulp");
 
@@ -25,5 +25,6 @@ module.exports = proGulp.task("config", () => {
             .mapKeys((value, key) => key.replace(prefixRegexp, ""));
     }
     const code = `window.APP_CONFIG = ${JSON.stringify(config, null, 4)};`;
+    fs.ensureDirSync(BUILD_DIR);
     fs.writeFileSync(`${BUILD_DIR}/app-config.js`, code);
 });


### PR DESCRIPTION
If you run sd-builder config task when there is not the build directory, it raise the following error:

```sh
Unhandled rejection Error: ENOENT: no such file or directory, open '$BUILD_DIR/app-config.js'
    at Object.fs.openSync (fs.js:558:18)
    at Object.fs.writeFileSync (fs.js:1223:33)
    at module.exports.proGulp.task (node_modules/sd-builder/src/tasks/config.js:28:8)
    at Object.promisifyWrapper (/node_modules/pro-gulp/src/lib/promisify.js:21:19)
    at Object.tryCatcher (node_modules/pro-gulp/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (node_modules/pro-gulp/node_modules/bluebird/js/main/promise.js:510:31)
    at Promise._settlePromiseAt (node_modules/pro-gulp/node_modules/bluebird/js/main/promise.js:584:18)
    at Promise._settlePromises (node_modules/pro-gulp/node_modules/bluebird/js/main/promise.js:700:14)
    at Async._drainQueue (node_modules/pro-gulp/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (node_modules/pro-gulp/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues (node_modules/pro-gulp/node_modules/bluebird/js/main/async.js:15:14)
    at runCallback (timers.js:651:20)
    at tryOnImmediate (timers.js:624:5)
    at processImmediate [as _immediateCallback] (timers.js:596:5)
```

I open this PR with a possible way to solve this creating, if necessary, the build directory